### PR TITLE
Allow existing Queues to create topic

### DIFF
--- a/src/Provider/AwsProvider.php
+++ b/src/Provider/AwsProvider.php
@@ -20,7 +20,7 @@
  * @license     Apache License, Version 2.0
  */
 
-namespace Uecode\Bundle\QPushBundle\Provider;
+namespace Uecode\Bundle\QPushBundle\Provider;c
 
 use Aws\Common\Aws;
 use Aws\Sqs\SqsClient;
@@ -92,7 +92,9 @@ class AwsProvider extends AbstractProvider
      */
     public function create()
     {
-        $this->createQueue();
+        if (!$this->queueExists()) {
+            $this->createQueue();
+        }
 
         if ($this->options['push_notifications']) {
            // Create the SNS Topic


### PR DESCRIPTION
If you provide the Queue name (which already exists in SQS), but you don't have a Topic to respond to this queue, it will call the `create()` function, which will attempt to create the query again (although it already exists). Need to check that in the create function as well (and not only in the publish method).

I know it does not makes sense to call the `create` method and check if the Queue exists or not, but if not, a refactor would be need to separete que creation of the queue and the topic one, so that on publish method, if the topic is not created, we just called the createTopic method and not the create function.

Does this make sense to any of you guys? Or I'm doing anything wrong?
